### PR TITLE
Create wheels for linux arm

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,26 @@ jobs:
       with:
         name: wheels
         path: dist
+  
+  linux-cross:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [aarch64, armv7]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: messense/maturin-action@v1
+      with:
+        manylinux: auto
+        target: ${{ matrix.target }}
+        command: build
+        rust-toolchain: stable
+        args: --release --sdist -o dist --find-interpreter
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheels
+        path: dist
 
   windows:
     runs-on: windows-latest
@@ -61,7 +81,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [ macos, windows, linux ]
+    needs: [ macos, windows, linux, linux-cross ]
     steps:
       - uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
This commit adds a linux-cross job that builds wheels for linux armv8 (aarch64) and armv7.

Fixes #10 