### PR TITLE
Turn ResolvedPos.column and ResolvedSpan.end into properties

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,7 @@ impl ResolvedPos {
     fn line(&self) -> usize {
         self.0.line
     }
+    #[getter]
     fn column(&self) -> usize {
         self.0.column
     }
@@ -181,6 +182,7 @@ impl ResolvedSpan {
     fn begin(&self) -> ResolvedPos {
         ResolvedPos(self.0.begin)
     }
+    #[getter]
     fn end(&self) -> ResolvedPos {
         ResolvedPos(self.0.end)
     }


### PR DESCRIPTION
ResolvedPos.column and ResolvedSpan.end are currently exposed as methods instead of properties. This is not consistent with having ResolvedPos.line and ResolvedSpan.begin being exposed as properties.