### PR TITLE
Preserve negative integers in serde_to_starlark

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,12 @@ fn serde_to_starlark(x: serde_json::Value, heap: &Heap) -> anyhow::Result<Value<
         serde_json::Value::Null => Ok(Value::new_none()),
         serde_json::Value::Bool(x) => Ok(Value::new_bool(x)),
         serde_json::Value::Number(x) => {
+            // Integer branches must come before f64: a value that fits in i64
+            // (in particular, a negative that fails as_u64) needs to land as a
+            // Starlark int, not be widened to float.
             if let Some(x) = x.as_u64() {
+                Ok(heap.alloc(x))
+            } else if let Some(x) = x.as_i64() {
                 Ok(heap.alloc(x))
             } else if let Some(x) = x.as_f64() {
                 Ok(heap.alloc(x))

--- a/test/test_starlark.py
+++ b/test/test_starlark.py
@@ -72,6 +72,43 @@ def test_python_callable_with_kwargs():
     assert val == 10
 
 
+def test_python_callable_negative_int_preserves_type():
+    # A registered Python callable that returns an int must produce an int on
+    # the Starlark -> Python boundary, including negatives. The JSON-based
+    # value conversion needs an i64 branch; without it, negatives fall
+    # through to f64 and emerge on the Python side as float.
+    glb = sl.Globals.standard()
+    mod = sl.Module()
+
+    captured: dict[str, int] = {}
+
+    def return_int(x: int) -> int:
+        captured["x"] = x
+        return x
+
+    mod.add_callable("return_int", return_int)
+
+    cases: tuple[tuple[str, int], ...] = (
+        ("-(2 * 1024 * 1024 * 1024)", -(2 * 1024 * 1024 * 1024)),
+        ("-100", -100),
+        ("-1", -1),
+        ("0", 0),
+        ("1", 1),
+        ("100", 100),
+        ("(2 * 1024 * 1024 * 1024) - 1", (2 * 1024 * 1024 * 1024) - 1),
+    )
+    for literal, expected in cases:
+        ast = sl.parse("neg-int.star", f"return_int({literal})")
+        result = sl.eval(mod, ast, glb)
+        assert result == expected
+        assert isinstance(result, int) and not isinstance(result, bool), (
+            f"expected int, got {type(result).__name__}={result!r}"
+        )
+        assert isinstance(captured["x"], int) and not isinstance(captured["x"], bool), (
+            f"callable received {type(captured['x']).__name__}={captured['x']!r}"
+        )
+
+
 ADD_STAR = """
 def add(x, y, a, b):
     if a != "a":


### PR DESCRIPTION
`serde_to_starlark` had no `as_i64()` arm: numeric values that didn't fit in u64 — notably every negative integer — fell through to f64 and were heap-allocated as Starlark floats. As a result, a Python value that arrived via the JSON conversion path emerged on the Starlark side as float whenever it was negative, and a Python callable returning a negative int produced a Python float on the way back through value_to_pyobject. This broke any downstream consumer that type-checks for int.

Add the missing `as_i64()` arm between the u64 and f64 attempts so values that fit in i64 stay integer. Add a regression test that calls a Python callable from Starlark with negative, zero, and positive literals and asserts the returned type on the Python side is int.

🤖 Generated with [Claude Code](https://claude.com/claude-code)