### PR TITLE
eval, FrozenModule.call: add check_cancelled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ extern crate starlark;
 extern crate starlark_derive;
 extern crate thiserror;
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::{self, Display};
 use std::sync::Mutex;
@@ -1054,17 +1055,31 @@ struct FrozenModule(starlark::environment::FrozenModule);
 
 #[pymethods]
 impl FrozenModule {
+    /// Accepts the same *check_cancelled* keyword argument as :func:`eval`.
+    /// That name is reserved here and cannot be passed as a Starlark keyword
+    /// argument to the called function.
+    ///
     /// .. versionadded:: 2025.2.2
     /// .. versionchanged:: 2025.2.3
     ///
     ///     Added support for keyword arguments.
-    #[pyo3(signature = (name, *args, **kwargs))]
+    #[pyo3(signature = (name, *args, check_cancelled=None, **kwargs))]
     fn call(
         slf: &Bound<'_, FrozenModule>,
         name: &str,
         args: &Bound<'_, PyTuple>,
+        check_cancelled: Option<Py<PyAny>>,
         kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
+        if let Some(ref cb) = check_cancelled {
+            if !cb.bind(slf.py()).is_callable() {
+                return Err(pyo3::exceptions::PyTypeError::new_err(
+                    "check_cancelled must be callable",
+                ));
+            }
+        }
+        let cancel_state = check_cancelled.map(CancelledState::new);
+
         let function = convert_anyhow_err(slf.get().0.get(name))?;
         let module = starlark::environment::Module::new();
         let sl_args = args
@@ -1079,16 +1094,25 @@ impl FrozenModule {
             None => Vec::new(),
         };
         let mut evaluator = starlark::eval::Evaluator::new(&module);
-        value_to_pyobject(convert_starlark_err(
-            evaluator.eval_function(
-                function.value(),
-                &sl_args,
-                &sl_kwargs
-                    .iter()
-                    .map(|(k, v)| (k.as_str(), v.dupe()))
-                    .collect::<Vec<(&str, Value<'_>)>>(),
-            ),
-        )?)
+        if let Some(state) = cancel_state.as_ref() {
+            evaluator.set_check_cancelled(Box::new(move || state.check()));
+        }
+        let result = convert_starlark_err(evaluator.eval_function(
+            function.value(),
+            &sl_args,
+            &sl_kwargs
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.dupe()))
+                .collect::<Vec<(&str, Value<'_>)>>(),
+        ))
+        .and_then(value_to_pyobject);
+
+        if let Some(state) = cancel_state.as_ref() {
+            if let Some(err) = state.take_error() {
+                return Err(err);
+            }
+        }
+        result
     }
 }
 
@@ -1130,18 +1154,80 @@ impl starlark::eval::FileLoader for FileLoader {
 
 // {{{ eval
 
+// Holds a Python `check_cancelled` callback plus a slot for an exception
+// raised inside it. The closure handed to `Evaluator::set_check_cancelled`
+// must return a `bool`, so a raising callback is reported by storing the
+// `PyErr` here and treating the call as a cancel. The caller pulls the
+// stashed exception out after evaluation and re-raises it in preference
+// to the generic "Evaluation cancelled" error.
+struct CancelledState {
+    callback: Py<PyAny>,
+    captured: RefCell<Option<PyErr>>,
+}
+
+impl CancelledState {
+    fn new(callback: Py<PyAny>) -> Self {
+        Self {
+            callback,
+            captured: RefCell::new(None),
+        }
+    }
+
+    fn check(&self) -> bool {
+        if self.captured.borrow().is_some() {
+            return true;
+        }
+        Python::attach(|py| {
+            match self
+                .callback
+                .call0(py)
+                .and_then(|ret| ret.bind(py).is_truthy())
+            {
+                Ok(b) => b,
+                Err(e) => {
+                    *self.captured.borrow_mut() = Some(e);
+                    true
+                }
+            }
+        })
+    }
+
+    fn take_error(&self) -> Option<PyErr> {
+        self.captured.borrow_mut().take()
+    }
+}
+
+/// :arg check_cancelled: An optional zero-argument callable invoked
+///     periodically (roughly every 1000 bytecode instructions). If it returns
+///     a truthy value, evaluation aborts and :class:`StarlarkError` is raised.
+///     If it raises a Python exception, evaluation aborts and that exception
+///     propagates to the caller. The callback must not access *module*:
+///     the module is locked during evaluation and re-entry will deadlock.
+///     Cancellation is scoped to this :func:`eval` call; nested
+///     :func:`eval` calls (e.g. from a :class:`FileLoader`) need their
+///     own callback.
 /// :returns: the value returned by the evaluation, after :ref:`object-conversion`.
 #[pyfunction]
 #[pyo3(
-    signature = (module, ast, globals, file_loader=None),
-    text_signature = "(module: Module, ast: AstModule, globals: Globals, file_loader: FileLoader | None = None) -> object"
+    signature = (module, ast, globals, file_loader=None, *, check_cancelled=None),
+    text_signature = "(module: Module, ast: AstModule, globals: Globals, file_loader: FileLoader | None = None, *, check_cancelled: Callable[[], bool] | None = None) -> object"
 )]
 fn eval(
     module: &mut Module,
     ast: &Bound<AstModule>,
     globals: &Globals,
     file_loader: Option<&Bound<FileLoader>>,
+    check_cancelled: Option<Py<PyAny>>,
 ) -> PyResult<Py<PyAny>> {
+    if let Some(ref cb) = check_cancelled {
+        if !cb.bind(ast.py()).is_callable() {
+            return Err(pyo3::exceptions::PyTypeError::new_err(
+                "check_cancelled must be callable",
+            ));
+        }
+    }
+    let cancel_state = check_cancelled.map(CancelledState::new);
+
     let tail = |evaluator: &mut starlark::eval::Evaluator| {
         // Stupid: eval_module consumes the AST. Clone it.
         value_to_pyobject(convert_starlark_err(
@@ -1150,18 +1236,31 @@ fn eval(
     };
 
     let mod_locked = module.0.lock_py_attached(ast.py()).unwrap();
-    match file_loader {
+    let result = match file_loader {
         Some(loader_cell) => {
             let loader_ref = loader_cell.borrow();
             let mut evaluator = starlark::eval::Evaluator::new(&mod_locked);
             evaluator.set_loader(&*loader_ref);
+            if let Some(state) = cancel_state.as_ref() {
+                evaluator.set_check_cancelled(Box::new(move || state.check()));
+            }
             tail(&mut evaluator)
         }
         None => {
             let mut evaluator = starlark::eval::Evaluator::new(&mod_locked);
+            if let Some(state) = cancel_state.as_ref() {
+                evaluator.set_check_cancelled(Box::new(move || state.check()));
+            }
             tail(&mut evaluator)
         }
+    };
+
+    if let Some(state) = cancel_state.as_ref() {
+        if let Some(err) = state.take_error() {
+            return Err(err);
+        }
     }
+    result
 }
 
 // }}}

--- a/starlark.pyi
+++ b/starlark.pyi
@@ -163,7 +163,13 @@ class Globals:
 
 @final
 class FrozenModule:
-    def call(self, name: str, *args: object, **kwargs: object) -> object: ...
+    def call(
+        self,
+        name: str,
+        *args: object,
+        check_cancelled: Callable[[], bool] | None = None,
+        **kwargs: object,
+    ) -> object: ...
 
 @final
 class Module:
@@ -182,4 +188,6 @@ def eval(
     ast: AstModule,
     globals: Globals,
     file_loader: FileLoader | None = None,
+    *,
+    check_cancelled: Callable[[], bool] | None = None,
 ) -> object: ...

--- a/test/test_starlark.py
+++ b/test/test_starlark.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+import pytest
+
 import starlark as sl
 
 
@@ -235,6 +237,131 @@ def test_opaue_python_obj():
     myobj = MyObj(5)
     myobj2 = fmod.call("identity", sl.OpaquePythonObject(myobj))
     assert myobj is myobj2
+
+# }}}
+
+
+# {{{ cancellation
+
+INFINITE_LOOP_STAR = """
+def busy():
+    x = 0
+    for _ in range(1000000000):
+        x = x + 1
+    return x
+busy()
+"""
+
+
+def test_check_cancelled_aborts_evaluation():
+    glb = sl.Globals.standard()
+    mod = sl.Module()
+    ast = sl.parse("cancel.star", INFINITE_LOOP_STAR)
+
+    counter: dict[str, int] = {"n": 0}
+
+    def cancel():
+        counter["n"] += 1
+        return counter["n"] >= 1
+
+    with pytest.raises(sl.StarlarkError):
+        sl.eval(mod, ast, glb, check_cancelled=cancel)
+
+    assert counter["n"] >= 1
+
+
+def test_check_cancelled_never_triggers_for_quick_eval():
+    glb = sl.Globals.standard()
+    mod = sl.Module()
+    ast = sl.parse("quick.star", "1 + 2")
+
+    counter: dict[str, int] = {"n": 0}
+
+    def cancel():
+        counter["n"] += 1
+        return False
+
+    assert sl.eval(mod, ast, glb, check_cancelled=cancel) == 3
+    assert counter["n"] == 0
+
+
+def test_check_cancelled_aborts_on_truthy_int():
+    glb = sl.Globals.standard()
+    mod = sl.Module()
+    ast = sl.parse("truthy.star", INFINITE_LOOP_STAR)
+
+    def cancel():
+        return 1
+
+    with pytest.raises(sl.StarlarkError):
+        # Intentional non-bool return: verifies is_truthy semantics.
+        sl.eval(mod, ast, glb, check_cancelled=cancel)  # pyright: ignore[reportArgumentType]
+
+
+def test_check_cancelled_rejects_non_callable():
+    glb = sl.Globals.standard()
+    mod = sl.Module()
+    ast = sl.parse("non-callable.star", "1")
+
+    with pytest.raises(TypeError, match="callable"):
+        # Intentional non-callable: verifies runtime rejection.
+        sl.eval(mod, ast, glb, check_cancelled=42)  # pyright: ignore[reportArgumentType]
+
+
+def test_check_cancelled_propagates_python_exception():
+    glb = sl.Globals.standard()
+    mod = sl.Module()
+    ast = sl.parse("cancel-raises.star", INFINITE_LOOP_STAR)
+
+    class BoomError(RuntimeError):
+        pass
+
+    def cancel():
+        raise BoomError("kaboom")
+
+    with pytest.raises(BoomError, match="kaboom"):
+        sl.eval(mod, ast, glb, check_cancelled=cancel)
+
+
+FROZEN_LOOP_STAR = """
+def loop():
+    for _ in range(1000000000):
+        pass
+    return 0
+"""
+
+
+def test_frozen_module_call_check_cancelled_aborts():
+    glb = sl.Globals.standard()
+    mod = sl.Module()
+    sl.eval(mod, sl.parse("frozen-loop.star", FROZEN_LOOP_STAR), glb)
+    fmod = mod.freeze()
+
+    counter: dict[str, int] = {"n": 0}
+
+    def cancel():
+        counter["n"] += 1
+        return counter["n"] >= 1
+
+    with pytest.raises(sl.StarlarkError):
+        fmod.call("loop", check_cancelled=cancel)
+    assert counter["n"] >= 1
+
+
+def test_frozen_module_call_check_cancelled_propagates_python_exception():
+    glb = sl.Globals.standard()
+    mod = sl.Module()
+    sl.eval(mod, sl.parse("frozen-loop2.star", FROZEN_LOOP_STAR), glb)
+    fmod = mod.freeze()
+
+    class BoomError(RuntimeError):
+        pass
+
+    def cancel():
+        raise BoomError("kaboom")
+
+    with pytest.raises(BoomError, match="kaboom"):
+        fmod.call("loop", check_cancelled=cancel)
 
 # }}}
 


### PR DESCRIPTION
This adds a keyword-only `check_cancelled` argument to `eval()` and to `FrozenModule.call()`:

- `check_cancelled: Callable[[], bool] | None` — invoked periodically (≈ every 1000 bytecode instructions). A truthy return aborts evaluation with `StarlarkError`; a raised exception propagates to the caller. Wraps [`Evaluator::set_check_cancelled`][1].

Truthiness uses `PyAny::is_truthy` to match the docstring's "truthy value" wording. Non-callable values are rejected at the call boundary. On `FrozenModule.call`, the name `check_cancelled` is reserved and cannot be passed as a Starlark keyword argument to the called function.

> An earlier revision of this PR also added `max_callstack_size`. That knob was dropped here so the three deterministic resource limits (callstack / tick count / heap size) can land together in a follow-up where their shape — flat kwargs vs. an `EvalOptions` bundle — can be considered coherently.

## Tests

Seven new tests covering, for `eval()`: bool-truthy abort, never-fires-for-quick-eval, non-bool truthy abort, non-callable rejection, raised-exception propagation; for `FrozenModule.call`: cancel abort and raised-exception propagation. All 34 tests pass. Local CI checks (ruff, typos, basedpyright, mypy stubtest, pytest, Sphinx with \`-W --keep-going -n\`, examples) all green.

## Related, not included

- `convert_starlark_err` currently flattens wrapped `PyErr`s via `e.to_string()`, losing the exception type at `FileLoader::load`, `PythonCallableValue::invoke`, and the new cancel callback. A downcast would preserve types uniformly but is a behavior change worth its own PR.
- The deterministic resource limits (`set_max_callstack_size`, `set_max_tick_count`, `set_max_heap_size`) are a coherent follow-up — together they cover Starlark's three DOS-prevention vectors, and pairing the design discussion (likely around an \`EvalOptions\` bundle) makes more sense than landing them piecemeal.

[1]: https://docs.rs/starlark/0.14.2/starlark/eval/struct.Evaluator.html#method.set_check_cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)